### PR TITLE
chore(build): allow setting of port via env

### DIFF
--- a/packages/build/bin/server.js
+++ b/packages/build/bin/server.js
@@ -3,6 +3,7 @@
 const { Observer } = require('../dist/src/observer')
 
 const options = {
+  port: process.env.PORT || 8080,
   dataPath: '.data',
   vendor: ['react', 'react-dom', 'react-helmet', 'lodash', 'typestyle'],
 }


### PR DESCRIPTION
To also be able to run multiple dev servers at the same time make http port of each instance settable through the env.