### PR TITLE
Bug appfolder

### DIFF
--- a/packages/build/src/generate/express.ts
+++ b/packages/build/src/generate/express.ts
@@ -48,6 +48,7 @@ export class Express extends Command {
       `const requireRoute = (r) => {
         try { 
           const route = require("./routes/"+r).default;
+          route.cwd = "${this.appFolder}"
           if(!SGRoutes.routeIsValid(route)){
             throw new Error('Route not valid')
           }

--- a/packages/build/src/generate/express.ts
+++ b/packages/build/src/generate/express.ts
@@ -40,7 +40,7 @@ export class Express extends Command {
       `app.use(morgan('combined'));`,
       'app.use(bodyParser.urlencoded({ extended: true }));',
       'app.use(bodyParser.json());',
-      'app.use(express.static(`${process.cwd()}/dist/assets/static`));',
+      `app.use(express.static('${this.appFolder}/dist/assets/static'));`,
       `const registerRoute = (route) => {
         try { route.register(app) }
         catch(error) { console.log('error registering route:', route, error) }
@@ -61,7 +61,9 @@ export class Express extends Command {
   }
 
   private body(routes: string[]) {
-    return `const routes = [${routes.map(r => `requireRoute("${r}"),`)}].filter(v=>!!v).sort(SGRoutes.routeSort);`
+    return `const routes = [${routes.map(
+      r => `requireRoute("${r}"),`
+    )}].filter(v=>!!v).sort(SGRoutes.routeSort);`
   }
 
   private footer() {

--- a/packages/routes/src/Route.tsx
+++ b/packages/routes/src/Route.tsx
@@ -12,6 +12,8 @@ export abstract class Route {
   static apiKey?: string
   // cache in seconds
   static cache: number = 0
+  // cwd
+  static cwd: string = process.cwd()
   // http method
   static method: string
   /**
@@ -29,7 +31,7 @@ export abstract class Route {
 
   // helper for express to call this route; applies middleware
   static async handle(req: Request, res: Response) {
-    const ctx = new RouteContext(req, res)
+    const ctx = new RouteContext(req, res, this.cwd)
     this.pipeline.reduce(this.applyMiddleware.bind(this, ctx), false)
   }
 

--- a/packages/routes/src/RouteContext.ts
+++ b/packages/routes/src/RouteContext.ts
@@ -61,7 +61,7 @@ export class RouteContext {
   }
 
   private renderUMD(pageSource: string, data: any) {
-    const pagePath = `${process.cwd()}/dist/assets/pages/${pageSource}.js`
+    const pagePath = `../dist/assets/pages/${pageSource}.js`
     const pagePathServer = pagePath.replace('.js', '-server.js')
     const pageBlob = fs.readFileSync(pagePath, 'utf-8')
     const pageBlobServer = fs.readFileSync(pagePathServer, 'utf-8')

--- a/packages/routes/src/RouteContext.ts
+++ b/packages/routes/src/RouteContext.ts
@@ -9,10 +9,12 @@ import * as rfs from 'require-from-string'
  * Provides functionality to everything you might want to do in context of a request.
  */
 export class RouteContext {
+  cwd: string
   request: Request
   response: Response
 
-  constructor(request: Request, response: Response) {
+  constructor(request: Request, response: Response, cwd: string) {
+    this.cwd = cwd
     this.request = request
     this.response = response
   }
@@ -60,8 +62,8 @@ export class RouteContext {
     this.response.send(html)
   }
 
-  private renderUMD(pageSource: string, data: any) {
-    const pagePath = `../dist/assets/pages/${pageSource}.js`
+  private renderUMD = (pageSource: string, data: any) => {
+    const pagePath = `${this.cwd}/dist/assets/pages/${pageSource}.js`
     const pagePathServer = pagePath.replace('.js', '-server.js')
     const pageBlob = fs.readFileSync(pagePath, 'utf-8')
     const pageBlobServer = fs.readFileSync(pagePathServer, 'utf-8')


### PR DESCRIPTION
The problem occurs when you start Observer or Builder with an app folder other than process.cwd().
The static folder and RouteContext were used with the folder process.cwd() - they were changed to relative paths.