### PR TITLE
chore: enable coverage tools to display coverage infos

### DIFF
--- a/packages/commands-http/package.json
+++ b/packages/commands-http/package.json
@@ -59,6 +59,7 @@
     ],
     "reporter": [
       "html",
+      "lcov",
       "text",
       "text-summary"
     ]


### PR DESCRIPTION
This changes allows tools and extensions like [Coverage Gutters](https://marketplace.visualstudio.com/items?itemName=ryanluker.vscode-coverage-gutters)
to display valuable information about code coverage