### PR TITLE
chore(deploy-aws): fix binary name clashing

### DIFF
--- a/packages/deploy-aws/package.json
+++ b/packages/deploy-aws/package.json
@@ -6,8 +6,8 @@
   "types": "dist/src/index.d.ts",
   "bin": {
     "seagull-deploy": "./bin/deploy.js",
-    "seagull-diff": "./bin/diff.js",
-    "seagull-pipeline": "./bin/pipeline.js"
+    "seagull-diff-project": "./bin/diff.js",
+    "seagull-update-pipeline": "./bin/pipeline.js"
   },
   "scripts": {
     "build": "rm -rf dist && tsc",


### PR DESCRIPTION
Currently this package names its binaries the same as @seagull/pipeline.
This rename will fix it.