### PR TITLE
testing-dependencies-fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@
 
 ### Patch Changes
 
+## 17.0.0
+
+- seagull/routes -> dependencies reorganized due to build still bundling tests
+- seagull/test-routes -> moved from routes
+
 ## 16.2.1
 
 - seagull/build -> server bundling - testing library excluded

--- a/package-lock.json
+++ b/package-lock.json
@@ -4146,9 +4146,9 @@
       "dev": true
     },
     "buffer": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.4.0.tgz",
-      "integrity": "sha512-Xpgy0IwHK2N01ncykXTy6FpCWuM+CJSHoPVBLyNqyrWxsedpLvwsYUhf0ME3WRFNUhos0dMamz9cOS/xRDtU5g==",
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.4.2.tgz",
+      "integrity": "sha512-iy9koArjAFCzGnx3ZvNA6Z0clIbbFgbdWQ0mKD3hO0krOrZh8UgA6qMKcZvwLJxS+D6iVR76+5/pV56yMNYTag==",
       "requires": {
         "base64-js": "^1.0.2",
         "ieee754": "^1.1.4"
@@ -6171,9 +6171,9 @@
       "integrity": "sha512-GJCAeDBKfREgkBtgrYSf9hQy9kTb3helv0zGdzqhM7iAkW8FA/ZF97VQDbwFiwIT8MQLLOe5VlPZOEvZAqtUAQ=="
     },
     "electron-to-chromium": {
-      "version": "1.3.241",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.241.tgz",
-      "integrity": "sha512-Gb9E6nWZlbgjDDNe5cAvMJixtn79krNJ70EDpq/M10lkGo7PGtBUe7Y0CYVHsBScRwi6ybCS+YetXAN9ysAHDg=="
+      "version": "1.3.243",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.243.tgz",
+      "integrity": "sha512-+edFdHGxLSmAKftXa5xZIg19rHkkJLiW+tRu0VMVG3RKztyeKX7d3pXf707lS6+BxB9uBun3RShbxCI1PtBAgQ=="
     },
     "elliptic": {
       "version": "6.5.0",

--- a/packages/build/src/services/bundler/lambda.ts
+++ b/packages/build/src/services/bundler/lambda.ts
@@ -30,7 +30,7 @@ export class LambdaBundleService {
     const { src, dst } = this.bundlerPaths()
     const config = {
       dstFile: dst,
-      excludes: ['aws-sdk', '@seagull/testing'],
+      excludes: ['aws-sdk'],
       srcFile: src,
     }
     this.bundler = new BundleWorker()

--- a/packages/routes/package.json
+++ b/packages/routes/package.json
@@ -36,7 +36,7 @@
     "@seagull/mock-process": "^16.2.1",
     "@seagull/mode": "^16.2.1",
     "@seagull/pages": "^16.2.1",
-    "@seagull/testing": "^16.2.1",
+    "@seagull/test-routes": "16.2.1",
     "@seagull/tslint": "^16.2.1",
     "@types/express": "^4.16.0",
     "@types/lodash": "^4.14.123",

--- a/packages/routes/src/HttpMethod.ts
+++ b/packages/routes/src/HttpMethod.ts
@@ -1,0 +1,1 @@
+export type HttpMethod = 'GET' | 'POST' | 'get' | 'post'

--- a/packages/routes/src/Route.tsx
+++ b/packages/routes/src/Route.tsx
@@ -2,9 +2,8 @@ import { httpServicesModule } from '@seagull/services-http'
 import { soapServicesModule } from '@seagull/services-soap'
 import { Express, Request, Response } from 'express'
 import { ContainerModule } from 'inversify'
-import { HttpMethod } from '.'
+import { HttpMethod } from './HttpMethod'
 import { RouteContext } from './RouteContext'
-import { RouteContextMock } from './RouteContextMock'
 
 type Middleware = (ctx: RouteContext) => Promise<boolean | void>
 

--- a/packages/routes/src/index.ts
+++ b/packages/routes/src/index.ts
@@ -1,5 +1,5 @@
+export * from './HttpMethod'
 export * from './Route'
-export * from './RouteTest'
 export * from './RouteContext'
 export * from './RouteRequestProps'
 export * from './validation'

--- a/packages/routes/test/Route.ts
+++ b/packages/routes/test/Route.ts
@@ -1,8 +1,6 @@
-import { Http } from '@seagull/services-http'
 import { expect } from 'chai'
 import 'chai/register-should'
-import { ContainerModule, injectable } from 'inversify'
-import { skip, slow, suite, test, timeout } from 'mocha-typescript'
+import { suite, test } from 'mocha-typescript'
 import * as httpMocks from 'node-mocks-http'
 import { Route, RouteContext } from '../src'
 

--- a/packages/routes/test/RouteApiKey.tsx
+++ b/packages/routes/test/RouteApiKey.tsx
@@ -1,7 +1,7 @@
+import { RouteTest } from '@seagull/test-routes'
 import 'chai/register-should'
-import { blockParams } from 'handlebars'
-import { skip, slow, suite, test, timeout } from 'mocha-typescript'
-import { Route, RouteContext, RouteTest } from '../src'
+import { suite, test } from 'mocha-typescript'
+import { Route, RouteContext } from '../src'
 
 class DemoRoute extends Route {
   static apiKey = '2135t'

--- a/packages/routes/test/RouteAsync.tsx
+++ b/packages/routes/test/RouteAsync.tsx
@@ -1,6 +1,7 @@
+import { RouteTest } from '@seagull/test-routes'
 import { expect } from 'chai'
 import { suite, test } from 'mocha-typescript'
-import { Route, RouteContext, RouteTest } from '../src'
+import { Route, RouteContext } from '../src'
 
 class DemoRoute extends Route {
   static path = '/:id'

--- a/packages/routes/test/RouteCache.tsx
+++ b/packages/routes/test/RouteCache.tsx
@@ -1,6 +1,7 @@
+import { RouteTest } from '@seagull/test-routes'
 import 'chai/register-should'
 import { skip, slow, suite, test, timeout } from 'mocha-typescript'
-import { Route, RouteContext, RouteTest } from '../src'
+import { Route, RouteContext } from '../src'
 
 class DemoRoute extends Route {
   static path = '/'

--- a/packages/routes/test/RouteHTML.tsx
+++ b/packages/routes/test/RouteHTML.tsx
@@ -1,6 +1,7 @@
+import { RouteTest } from '@seagull/test-routes'
 import 'chai/register-should'
-import { skip, slow, suite, test, timeout } from 'mocha-typescript'
-import { Route, RouteContext, RouteTest } from '../src'
+import { suite, test } from 'mocha-typescript'
+import { Route, RouteContext } from '../src'
 
 class DemoRoute extends Route {
   static path = '/'

--- a/packages/routes/test/RouteInjectable.ts
+++ b/packages/routes/test/RouteInjectable.ts
@@ -1,8 +1,9 @@
 import { Http } from '@seagull/services-http'
+import { RouteTest } from '@seagull/test-routes'
 import { expect } from 'chai'
 import 'chai/register-should'
 import { ContainerModule, injectable } from 'inversify'
-import { skip, slow, suite, test, timeout } from 'mocha-typescript'
+import { suite, test } from 'mocha-typescript'
 import * as httpMocks from 'node-mocks-http'
 import { Route, RouteContext } from '../src'
 

--- a/packages/routes/test/RouteJSON.tsx
+++ b/packages/routes/test/RouteJSON.tsx
@@ -1,6 +1,7 @@
+import { RouteTest } from '@seagull/test-routes'
 import 'chai/register-should'
-import { skip, slow, suite, test, timeout } from 'mocha-typescript'
-import { Route, RouteContext, RouteTest } from '../src'
+import { suite, test } from 'mocha-typescript'
+import { Route, RouteContext } from '../src'
 
 class DemoRoute extends Route {
   static path = '/'

--- a/packages/routes/test/RouteParams.tsx
+++ b/packages/routes/test/RouteParams.tsx
@@ -1,6 +1,7 @@
+import { RouteTest } from '@seagull/test-routes'
 import 'chai/register-should'
-import { skip, slow, suite, test, timeout } from 'mocha-typescript'
-import { Route, RouteContext, RouteTest } from '../src'
+import { suite, test } from 'mocha-typescript'
+import { Route, RouteContext } from '../src'
 
 class DemoRoute extends Route {
   static path = '/:id'

--- a/packages/routes/test/RouteRegistration.tsx
+++ b/packages/routes/test/RouteRegistration.tsx
@@ -1,8 +1,9 @@
+import { RouteTest } from '@seagull/test-routes'
 import 'chai/register-should'
 import * as express from 'express'
 import { suite, test } from 'mocha-typescript'
 import * as httpMocks from 'node-mocks-http'
-import { Route, RouteContext, RouteTest } from '../src'
+import { Route, RouteContext } from '../src'
 
 class DemoRoute extends Route {
   static path = '/'

--- a/packages/routes/test/RouteRender.tsx
+++ b/packages/routes/test/RouteRender.tsx
@@ -1,11 +1,12 @@
 import { FS } from '@seagull/commands-fs'
 import { Process as ProcessMock } from '@seagull/mock-process'
 import { Page } from '@seagull/pages'
+import { RouteTest } from '@seagull/test-routes'
 import 'chai/register-should'
-import { skip, slow, suite, test, timeout } from 'mocha-typescript'
+import { suite, test } from 'mocha-typescript'
 import * as path from 'path'
 import * as React from 'react'
-import { Route, RouteContext, RouteTest } from '../src'
+import { Route, RouteContext } from '../src'
 
 class DemoPage extends Page {
   html() {

--- a/packages/routes/test/RouteRequestProps.tsx
+++ b/packages/routes/test/RouteRequestProps.tsx
@@ -1,11 +1,12 @@
+import { RouteTest } from '@seagull/test-routes'
 import { expect } from 'chai'
 import 'chai/register-should'
 import * as CV from 'class-validator'
 import { EventEmitter } from 'events'
 import * as express from 'express'
-import { skip, slow, suite, test, timeout } from 'mocha-typescript'
+import { suite, test, timeout } from 'mocha-typescript'
 import * as httpMocks from 'node-mocks-http'
-import { Route, RouteContext, RouteRequestProps, RouteTest } from '../src'
+import { Route, RouteContext, RouteRequestProps } from '../src'
 
 class RouteParams extends RouteRequestProps {
   // geter and setter (for example to convert string to num) are working like expected

--- a/packages/routes/test/RouteTest.tsx
+++ b/packages/routes/test/RouteTest.tsx
@@ -1,10 +1,11 @@
-import { Http } from '@seagull/services-http'
 import { Mode } from '@seagull/mode'
+import { Http } from '@seagull/services-http'
+import { RouteTest } from '@seagull/test-routes'
 import { expect } from 'chai'
 import 'chai/register-should'
 import { ContainerModule, injectable } from 'inversify'
 import { skip, slow, suite, test, timeout } from 'mocha-typescript'
-import { Route, RouteContext, RouteTest } from '../src'
+import { Route, RouteContext } from '../src'
 
 class DemoRoute extends Route {
   static path = '/'

--- a/packages/routes/test/RouteText.tsx
+++ b/packages/routes/test/RouteText.tsx
@@ -1,6 +1,7 @@
+import { RouteTest } from '@seagull/test-routes'
 import 'chai/register-should'
-import { skip, slow, suite, test, timeout } from 'mocha-typescript'
-import { Route, RouteContext, RouteTest } from '../src'
+import { suite, test } from 'mocha-typescript'
+import { Route, RouteContext } from '../src'
 
 class DemoRoute extends Route {
   static path = '/'

--- a/packages/routes/test/validation.ts
+++ b/packages/routes/test/validation.ts
@@ -1,6 +1,6 @@
 // tslint:disable:no-unused-expression
 import 'chai/register-should'
-import { skip, slow, suite, test, timeout } from 'mocha-typescript'
+import { suite, test } from 'mocha-typescript'
 import { pathIsValid, Route, RouteContext, routeIsValid } from '../src'
 
 class DemoRoute extends Route {

--- a/packages/test-routes/.gitignore
+++ b/packages/test-routes/.gitignore
@@ -1,0 +1,17 @@
+# dependencies & NPM stuff
+node_modules
+npm-debug.log
+
+# documentation artifacts
+docs
+
+# build outputs
+dist
+
+# test artifacts
+.nyc_output
+coverage
+
+# junk files
+.DS_Store
+old_code

--- a/packages/test-routes/package.json
+++ b/packages/test-routes/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "@seagull/testing",
+  "name": "@seagull/test-routes",
   "version": "16.2.1",
-  "description": "Testing Utilities for the Seagull Framework",
-  "main": "dist/src/index.js",
-  "types": "dist/src/index.d.ts",
+  "description": "A basic test class for the route implementation of the Seagull Framework",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "scripts": {
     "build": "rm -rf dist && tsc",
-    "test": "tslint --fix src/**/*.ts test/**/*.ts && mocha --opts test/mocha.opts",
+    "test": "echo \"nothing to test\"",
     "test:coverage": "tslint --fix src/**/*.ts test/**/*.ts && nyc mocha --opts test/mocha.opts",
     "test:watch": "npm run test -- --watch --reporter min",
     "docs": "rm -rf docs && typedoc --mode modules --ignoreCompilerErrors --excludeExternals --excludePrivate --excludeNotExported --out docs src"
@@ -33,24 +33,13 @@
   },
   "homepage": "https://github.com/seagull-js/seagull#readme",
   "devDependencies": {
-    "@seagull/tslint": "^16.2.1",
-    "@types/lodash": "^4.14.123",
-    "@types/mocha": "^5.2.7",
-    "aws-sdk": "*",
-    "inversify": "5.0.1",
-    "mocha": "^5.2.0",
-    "mocha-typescript": "^1.1.17"
-  },
-  "dependencies": {
-    "@seagull/mock": "^16.2.1",
     "@seagull/mode": "^16.2.1",
-    "@seagull/sandbox": "^16.2.1",
-    "@seagull/seed": "^16.2.1",
-    "inversify": "^5.0.1"
+    "@seagull/pages": "^16.2.1",
+    "@seagull/services-http": "^16.2.1",
+    "@seagull/testing": "^16.2.1",
+    "@seagull/tslint": "^16.2.1"
   },
-  "peerDependencies": {
-    "aws-sdk": "*"
-  },
+  "dependencies": {},
   "nyc": {
     "extension": [
       ".ts",

--- a/packages/test-routes/src/RouteContextMock.ts
+++ b/packages/test-routes/src/RouteContextMock.ts
@@ -1,10 +1,6 @@
-import { PageType, render } from '@seagull/pages'
+import { PageType } from '@seagull/pages'
 import { Request, Response } from 'express'
-import * as fs from 'fs'
 import { Container } from 'inversify'
-import { isString } from 'lodash'
-import * as rfs from 'require-from-string'
-import { RouteContext } from './RouteContext'
 
 type RouteContextCalls =
   | 'text'

--- a/packages/test-routes/src/RouteTest.tsx
+++ b/packages/test-routes/src/RouteTest.tsx
@@ -2,7 +2,6 @@ import { BasicTest } from '@seagull/testing'
 import { EventEmitter } from 'events'
 import { Request, Response } from 'express'
 import * as httpMocks from 'node-mocks-http'
-import { Route } from './Route'
 import { RouteContextMock } from './RouteContextMock'
 
 export type HttpMethod = 'GET' | 'POST' | 'get' | 'post'
@@ -12,7 +11,7 @@ interface Connection {
 }
 
 export abstract class RouteTest extends BasicTest {
-  abstract route: typeof Route
+  abstract route: any
 
   /**
    * Invokes the `route` with an mocked request and an response object.
@@ -37,7 +36,10 @@ export abstract class RouteTest extends BasicTest {
    * @param params Params object passed through TODO: think body vs query vs path params...
    */
 
-  async invokeMocked(path = '/', params: any = {}) {
+  async invokeMocked(
+    path = '/',
+    params: any = {}
+  ): Promise<RouteContextMock['results']> {
     const reqRes = this.requestAndResponse(this.route.method, path, params)
     const ctx = new RouteContextMock(reqRes.request, reqRes.response)
 

--- a/packages/test-routes/src/index.ts
+++ b/packages/test-routes/src/index.ts
@@ -1,0 +1,2 @@
+export * from './RouteTest'
+export * from './RouteContextMock'

--- a/packages/test-routes/tsconfig.json
+++ b/packages/test-routes/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": ["src/**/*", "test/**/*", "declarations.d.ts"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/test-routes/tslint.json
+++ b/packages/test-routes/tslint.json
@@ -1,0 +1,3 @@
+{
+  "extends": "@seagull/tslint"
+}


### PR DESCRIPTION
- seagull/routes -> dependencies reorganized due to build still bundling tests
- seagull/test-routes -> moved from routes